### PR TITLE
CEDS-1138 Add Declaration Object Factory Mapper

### DIFF
--- a/src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/ObjectFactory.java
+++ b/src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/ObjectFactory.java
@@ -37,4 +37,7 @@ public class ObjectFactory {
         return new MetaData();
     }
 
+    public wco.datamodel.wco.dec_dms._2.Declaration createDeclaration() {
+        return new wco.datamodel.wco.dec_dms._2.ObjectFactory().createDeclaration();
+    }
 }

--- a/updateSchema/declaration_mapper.txt
+++ b/updateSchema/declaration_mapper.txt
@@ -1,0 +1,3 @@
+    public wco.datamodel.wco.dec_dms._2.Declaration createDeclaration() {
+        return new wco.datamodel.wco.dec_dms._2.ObjectFactory().createDeclaration();
+    }

--- a/updateSchema/generate.sh
+++ b/updateSchema/generate.sh
@@ -23,5 +23,9 @@ generate
 log "Move generated schema to source folder... ✔"
 cp -R  wco/* ../src/main/java/
 
+# Add Declaration Object Mapper
+log "Add Declaration Object Mapper... ✔"
+sed -i '$e cat declaration_mapper.txt' ../src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/ObjectFactory.java
+
 # Clean up temporary files/directories
 clean


### PR DESCRIPTION
As part of the new mapping strategy, by using the Java generated model
classes, the `Declaration` instance is saved against a property called
`any` that is an attribute of the `Metadata.java` class.
The type of `any` is `Object.class`, so in order for the serialization
to work properly against the Declaration object we add to either replace
`any` with `Declaration` on the service or simply enter the method in
the `ObjectFactory.java` as part of the schema generation.
We decided to go with the latter.

with @mattclark-zerogravit