### PR TITLE
CEDS-4033 update exports be to scala 2.13

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.7.1","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java","-Xms100m","-Xmx100m","-classpath","/home/digital326490/.local/share/JetBrains/IdeaIC2022.2/Scala/launcher/sbt-launch.jar","-Dsbt.script=/usr/bin/sbt","xsbt.boot.Boot","-bsp"]}

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,8 @@ lazy val simpleReactiveMongo = Project(nameApp, file("."))
     scalaVersion        := "2.13.8",
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     crossScalaVersions  := Seq("2.11.12", "2.12.6", "2.13.8"),
-    majorVersion := 0
+    majorVersion := 0,
+    isPublicArtefact := true
   )
   .settings(scoverageSettings)
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,20 +3,19 @@ import sbt._
 val nameApp = "wco-dec"
 
 lazy val simpleReactiveMongo = Project(nameApp, file("."))
-  .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
+  .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning)
   .settings(
-    scalaVersion        := "2.11.12",
+    scalaVersion        := "2.13.8",
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
-    resolvers           += Resolver.jcenterRepo,
-    crossScalaVersions  := Seq("2.11.12", "2.12.6"),
-    makePublicallyAvailableOnBintray := true,
+    crossScalaVersions  := Seq("2.11.12", "2.12.6", "2.13.8"),
     majorVersion := 0
-).settings(scoverageSettings)
+  )
+  .settings(scoverageSettings)
 
 lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     coverageExcludedPackages := List("<empty>").mkString(";"),
-    coverageMinimum := 50,
+    coverageMinimumStmtTotal := 50,
     coverageFailOnMinimum := true,
     coverageHighlighting := true,
-    parallelExecution in Test := false
+    Test / parallelExecution := false
 )

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt._
 val nameApp = "wco-dec"
 
 lazy val simpleReactiveMongo = Project(nameApp, file("."))
-  .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning)
+  .enablePlugins(SbtAutoBuildPlugin)
   .settings(
     scalaVersion        := "2.13.8",
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object AppDependencies {
 
-  val jacksonVersion = "2.9.7"
+  val jacksonVersion = "2.11.3" // Pinned at 2.11.3 due to open issue https://github.com/FasterXML/jackson-dataformat-xml/issues/491
 
   val compile = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
@@ -14,8 +14,9 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "org.scalatest" %% "scalatest" % "3.0.4" % "test",
-    "org.pegdown" % "pegdown" % "1.6.0" % "test"
+    "org.scalatest" %% "scalatest" % "3.2.12" % "test",
+    "org.pegdown" % "pegdown" % "1.6.0" % "test",
+    "com.vladsch.flexmark"   % "flexmark-all"        % "0.62.2"            % "test"
   )
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,4 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.4.0")
-
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,8 @@
-resolvers ++= Seq(
-  Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns),
-  "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-)
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.4.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.13.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/AmountType.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/AmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;
 

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/CodeType.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/CodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;
 

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/DateTimeType.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/DateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;
 

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/IDType.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/IDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;
 

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/MeasureType.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/MeasureType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;
 

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/ObjectFactory.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/ObjectFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;
 

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/QuantityType.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/QuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;
 

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/TextType.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/TextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;
 

--- a/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/package-info.java
+++ b/src/main/java/un/unece/uncefact/data/standard/unqualifieddatatype/_6/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:6")
 package un.unece.uncefact.data.standard.unqualifieddatatype._6;

--- a/src/main/java/wco/datamodel/wco/dec_dms/_2/Declaration.java
+++ b/src/main/java/wco/datamodel/wco/dec_dms/_2/Declaration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.dec_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/dec_dms/_2/ObjectFactory.java
+++ b/src/main/java/wco/datamodel/wco/dec_dms/_2/ObjectFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.dec_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/dec_dms/_2/package-info.java
+++ b/src/main/java/wco/datamodel/wco/dec_dms/_2/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "urn:wco:datamodel:WCO:DEC-DMS:2", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package wco.datamodel.wco.dec_dms._2;

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AEOMutualRecognitionPartyIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AEOMutualRecognitionPartyIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AEOMutualRecognitionPartyRoleCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AEOMutualRecognitionPartyRoleCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentCategoryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentCategoryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentEffectiveDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentEffectiveDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentLPCOExemptionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentLPCOExemptionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalDocumentTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalInformationStatementCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalInformationStatementCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalInformationStatementDescriptionTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalInformationStatementDescriptionTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalInformationStatementTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AdditionalInformationStatementTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressCityNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressCityNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressCountryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressCountryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressCountrySubDivisionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressCountrySubDivisionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressCountrySubDivisionNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressCountrySubDivisionNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressLineTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressLineTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressPostcodeIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressPostcodeIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AddressTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AgentFunctionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AgentFunctionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AgentIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AgentIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AgentNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AgentNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AmendmentChangeReasonCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AmendmentChangeReasonCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansIdentificationTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansIdentificationTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansModeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansModeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ArrivalTransportMeansTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AuthenticationAuthenticationTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AuthenticationAuthenticationTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AuthenticatorNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AuthenticatorNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AuthorisationHolderCategoryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AuthorisationHolderCategoryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AuthorisationHolderIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/AuthorisationHolderIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansIdentificationTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansIdentificationTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansModeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansModeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansRegistrationNationalityCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansRegistrationNationalityCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BorderTransportMeansTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BuyerIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BuyerIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BuyerNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/BuyerNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CarrierIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CarrierIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CarrierNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CarrierNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ChargeDeductionChargesTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ChargeDeductionChargesTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ChargeDeductionOtherChargeDeductionAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ChargeDeductionOtherChargeDeductionAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ClassificationBindingTariffReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ClassificationBindingTariffReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ClassificationIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ClassificationIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ClassificationIdentificationTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ClassificationIdentificationTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ClassificationNameCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ClassificationNameCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CommodityDescriptionTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CommodityDescriptionTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CommunicationIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CommunicationIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CommunicationTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CommunicationTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsigneeIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsigneeIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsigneeNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsigneeNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsignmentContainerCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsignmentContainerCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsignorIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsignorIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsignorNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ConsignorNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ContactNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ContactNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CurrencyExchangeCurrencyTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CurrencyExchangeCurrencyTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CustomsValuationFreightChargeAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CustomsValuationFreightChargeAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CustomsValuationMethodCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/CustomsValuationMethodCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DangerousGoodsUNDGIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DangerousGoodsUNDGIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarantIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarantIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarantNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarantNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationAcceptanceDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationAcceptanceDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationDeclarationOfficeIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationDeclarationOfficeIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationFunctionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationFunctionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationFunctionalReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationFunctionalReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationGoodsItemQuantityType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationGoodsItemQuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationInvoiceAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationInvoiceAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationIssueDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationIssueDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationIssueLocationIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationIssueLocationIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationLoadingListQuantityType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationLoadingListQuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationSpecificCircumstancesCodeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationSpecificCircumstancesCodeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationTotalGrossMassMeasureType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationTotalGrossMassMeasureType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationTotalPackageQuantityType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationTotalPackageQuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DeclarationTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansIdentificationTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansIdentificationTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansModeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansModeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DepartureTransportMeansTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DestinationCountryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DestinationCountryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DestinationRegionIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DestinationRegionIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DomesticDutyTaxPartyIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DomesticDutyTaxPartyIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DomesticDutyTaxPartyRoleCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DomesticDutyTaxPartyRoleCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeAdValoremTaxBaseAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeAdValoremTaxBaseAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeDeductAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeDeductAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeDutyRegimeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeDutyRegimeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeQuotaOrderIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeQuotaOrderIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeSpecificTaxBaseQuantityType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeSpecificTaxBaseQuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/DutyTaxFeeTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ExitOfficeIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ExitOfficeIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ExportCountryCountryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ExportCountryCountryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ExporterIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ExporterIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ExporterNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ExporterNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/FreightPaymentMethodCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/FreightPaymentMethodCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsLocationIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsLocationIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsLocationNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsLocationNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsLocationTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsLocationTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsMeasureGrossMassMeasureType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsMeasureGrossMassMeasureType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsMeasureNetNetWeightMeasureType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsMeasureNetNetWeightMeasureType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsMeasureTariffQuantityType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsMeasureTariffQuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsShipmentExitDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsShipmentExitDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsShipmentTransactionNatureCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GoodsShipmentTransactionNatureCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentAgencyGoodsItemCustomsValueAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentAgencyGoodsItemCustomsValueAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentAgencyGoodsItemStatisticalValueAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentAgencyGoodsItemStatisticalValueAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentAgencyGoodsItemTransactionNatureCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentAgencyGoodsItemTransactionNatureCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentProcedureCurrentCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentProcedureCurrentCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentProcedurePreviousCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GovernmentProcedurePreviousCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GuaranteeOfficeIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/GuaranteeOfficeIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ImporterIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ImporterIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ImporterNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ImporterNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/InvoiceIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/InvoiceIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/InvoiceIssueDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/InvoiceIssueDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/InvoiceLineItemChargeAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/InvoiceLineItemChargeAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ItineraryRoutingCountryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ItineraryRoutingCountryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/LoadingLocationIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/LoadingLocationIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/LoadingLocationNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/LoadingLocationNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ManufacturerIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ManufacturerIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ManufacturerNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ManufacturerNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObjectFactory.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObjectFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeAccessCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeAccessCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeAmountAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeAmountAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeSecurityDetailsCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ObligationGuaranteeSecurityDetailsCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/OriginCountryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/OriginCountryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/OriginRegionIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/OriginRegionIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/OriginTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/OriginTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingHeightMeasureType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingHeightMeasureType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingLengthMeasureType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingLengthMeasureType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingMarksNumbersIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingMarksNumbersIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingPackingMaterialDescriptionTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingPackingMaterialDescriptionTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingQuantityQuantityType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingQuantityQuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingVolumeMeasureType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingVolumeMeasureType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingWidthMeasureType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PackagingWidthMeasureType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PayerIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PayerIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PayerNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PayerNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PaymentMethodCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PaymentMethodCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PaymentPaymentAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PaymentPaymentAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PaymentTaxAssessedAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PaymentTaxAssessedAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PointerDocumentSectionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PointerDocumentSectionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PointerTagIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PointerTagIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PresentationOfficeIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PresentationOfficeIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PreviousDocumentCategoryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PreviousDocumentCategoryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PreviousDocumentIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PreviousDocumentIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PreviousDocumentTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/PreviousDocumentTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/RefundRecipientPartyIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/RefundRecipientPartyIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/RefundRecipientPartyNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/RefundRecipientPartyNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SealIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SealIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SellerIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SellerIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SellerNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SellerNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SubmitterIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SubmitterIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SubmitterNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SubmitterNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SubmitterRoleCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SubmitterRoleCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SupervisingOfficeIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SupervisingOfficeIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SuretyIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SuretyIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SuretyNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/SuretyNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsConditionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsConditionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsCountryRelationshipCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsCountryRelationshipCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsDescriptionTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsDescriptionTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsLocationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsLocationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsLocationNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TradeTermsLocationNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TransportEquipmentIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/TransportEquipmentIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/UCRIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/UCRIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/UCRTraderAssignedReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/UCRTraderAssignedReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ValuationAdjustmentAdditionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/ValuationAdjustmentAdditionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/WarehouseIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/WarehouseIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/WarehouseTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/WarehouseTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/WriteOffAmountAmountType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/WriteOffAmountAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/WriteOffQuantityQuantityType.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/WriteOffQuantityQuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.declaration_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/package-info.java
+++ b/src/main/java/wco/datamodel/wco/declaration_ds/dms/_2/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "urn:wco:datamodel:WCO:Declaration_DS:DMS:2", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package wco.datamodel.wco.declaration_ds.dms._2;

--- a/src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/MetaData.java
+++ b/src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/MetaData.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.documentmetadata_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/ObjectFactory.java
+++ b/src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/ObjectFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.documentmetadata_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/package-info.java
+++ b/src/main/java/wco/datamodel/wco/documentmetadata_dms/_2/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "urn:wco:datamodel:WCO:DocumentMetaData-DMS:2", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package wco.datamodel.wco.documentmetadata_dms._2;

--- a/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataAgencyAssignedCustomizationCodeType.java
+++ b/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataAgencyAssignedCustomizationCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.metadata_ds_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataAgencyAssignedCustomizationVersionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataAgencyAssignedCustomizationVersionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.metadata_ds_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataResponsibleAgencyNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataResponsibleAgencyNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.metadata_ds_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataResponsibleCountryCodeType.java
+++ b/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataResponsibleCountryCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.metadata_ds_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataWCODataModelVersionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataWCODataModelVersionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.metadata_ds_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataWCOTypeNameTextType.java
+++ b/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/MetaDataWCOTypeNameTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.metadata_ds_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/ObjectFactory.java
+++ b/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/ObjectFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.metadata_ds_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/package-info.java
+++ b/src/main/java/wco/datamodel/wco/metadata_ds_dms/_2/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "urn:wco:datamodel:WCO:MetaData_DS-DMS:2")
 package wco.datamodel.wco.metadata_ds_dms._2;

--- a/src/main/java/wco/datamodel/wco/res_dms/_2/ObjectFactory.java
+++ b/src/main/java/wco/datamodel/wco/res_dms/_2/ObjectFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.res_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/res_dms/_2/Response.java
+++ b/src/main/java/wco/datamodel/wco/res_dms/_2/Response.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.res_dms._2;
 

--- a/src/main/java/wco/datamodel/wco/res_dms/_2/package-info.java
+++ b/src/main/java/wco/datamodel/wco/res_dms/_2/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "urn:wco:datamodel:WCO:RES-DMS:2", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package wco.datamodel.wco.res_dms._2;

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AdditionalInformationLimitDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AdditionalInformationLimitDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AdditionalInformationStatementCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AdditionalInformationStatementCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AdditionalInformationStatementDescriptionTextType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AdditionalInformationStatementDescriptionTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AdditionalInformationStatementTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AdditionalInformationStatementTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AmendmentChangeReasonCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AmendmentChangeReasonCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AppealOfficeIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/AppealOfficeIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/BankAccountIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/BankAccountIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/BankReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/BankReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/CommunicationIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/CommunicationIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/CommunicationTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/CommunicationTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ContactOfficeIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ContactOfficeIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationAcceptanceDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationAcceptanceDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationCancellationDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationCancellationDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationFunctionalReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationFunctionalReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationIdentificationIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationIdentificationIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationRejectionDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationRejectionDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationVersionIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DeclarationVersionIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeAdValoremTaxBaseAmountType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeAdValoremTaxBaseAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeDeductAmountType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeDeductAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeDutyRegimeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeDutyRegimeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeQuotaOrderIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeQuotaOrderIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeSpecificTaxBaseQuantityType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeSpecificTaxBaseQuantityType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeTypeCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/DutyTaxFeeTypeCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ErrorDescriptionTextType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ErrorDescriptionTextType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ErrorValidationCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ErrorValidationCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ObjectFactory.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ObjectFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ObligationGuaranteeReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ObligationGuaranteeReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PaymentDueDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PaymentDueDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PaymentPaymentAmountType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PaymentPaymentAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PaymentReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PaymentReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PaymentTaxAssessedAmountType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PaymentTaxAssessedAmountType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PointerDocumentSectionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PointerDocumentSectionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PointerTagIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/PointerTagIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ResponseFunctionCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ResponseFunctionCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ResponseFunctionalReferenceIDType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ResponseFunctionalReferenceIDType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ResponseIssueDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/ResponseIssueDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/StatusEffectiveDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/StatusEffectiveDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/StatusNameCodeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/StatusNameCodeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/StatusReleaseDateTimeType.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/StatusReleaseDateTimeType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package wco.datamodel.wco.response_ds.dms._2;
 

--- a/src/main/java/wco/datamodel/wco/response_ds/dms/_2/package-info.java
+++ b/src/main/java/wco/datamodel/wco/response_ds/dms/_2/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "urn:wco:datamodel:WCO:Response_DS:DMS:2", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package wco.datamodel.wco.response_ds.dms._2;

--- a/src/main/scala/uk/gov/hmrc/wco/dec/Declaration.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/Declaration.scala
@@ -16,10 +16,6 @@
 
 package uk.gov.hmrc.wco.dec
 
-import java.io.StringWriter
-import java.time.ZonedDateTime
-import java.util.Properties
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind._
@@ -33,7 +29,10 @@ import uk.gov.hmrc.wco.dec.utilities.JacksonMapper
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem.{Buyer, Consignee}
 import wco.datamodel.wco.declaration_ds.dms._2._
 
-import scala.collection.JavaConverters._
+import java.io.StringWriter
+import java.time.ZonedDateTime
+import java.util.Properties
+import scala.collection.JavaConverters.propertiesAsScalaMapConverter
 
 /*
 MetaData and Declaration schema generally consists of xsd:sequence definitions the order of which is reflected in the
@@ -92,7 +91,7 @@ object MetaData extends JacksonMapper {
 
   def fromProperties(props: Map[String, String]): MetaData = {
     val p = new Properties()
-    props.foreach(prop => p.put(prop._1, prop._2))
+    props.foreach(v => p.put(v._1, v._2))
     _props.readPropertiesAs(p, _schema, classOf[MetaData])
   }
 
@@ -851,19 +850,6 @@ object Address {
     consigneeAddress.setPostcodeID(addressPostcode)
 
     consigneeAddress
-  }
-
-  def test: Unit = {
-    val address = Address(
-      Some("Leeds"),
-      Some("GB"),
-      Some("GB"),
-      Some("UK"),
-      Some("GB"),
-      Some("LS1")
-    )
-    val consigneeAddress = address.as[Consignee.Address]
-    val buyersAddress = address.as[Buyer.Address]
   }
 }
 

--- a/src/main/scala/uk/gov/hmrc/wco/dec/Declaration.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/Declaration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ object MetaData extends JacksonMapper {
 
   def fromProperties(props: Map[String, String]): MetaData = {
     val p = new Properties()
-    p.putAll(props.asJava)
+    props.foreach(prop => p.put(prop._1, prop._2))
     _props.readPropertiesAs(p, _schema, classOf[MetaData])
   }
 

--- a/src/main/scala/uk/gov/hmrc/wco/dec/Response.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/Response.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/wco/dec/TypeCodeValues.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/TypeCodeValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/wco/dec/TypeCodeValues.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/TypeCodeValues.scala
@@ -28,7 +28,7 @@ object TypeCodeValues {
   def load(name: String): Seq[TypeCodeValue] = try {
     _mapper.readValue[Array[TypeCodeValue]](
       getClass.getResourceAsStream(s"/uk/gov/hmrc/wco/dec/$name.json"), classOf[Array[TypeCodeValue]]
-    )
+    ).toIndexedSeq
   } catch {
     case e: MismatchedInputException => throw new IllegalArgumentException(s"Unknown type code value list name: $name", e)
   }

--- a/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/common/InventoryLinkingCommonTypes.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/common/InventoryLinkingCommonTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/InventoryLinkingConsolidationRequest.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/InventoryLinkingConsolidationRequest.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.wco.dec.utilities.JacksonMapper
 
 import java.io.StringWriter
 import java.util.Properties
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.propertiesAsScalaMapConverter
 
 object InventoryLinkingConsolidationRequest extends JacksonMapper {
   final val inventoryLinking = "http://gov.uk/customs/inventoryLinking/v1"
@@ -33,7 +33,7 @@ object InventoryLinkingConsolidationRequest extends JacksonMapper {
 
   def fromProperties(props: Map[String, String]): InventoryLinkingConsolidationRequest = {
     val p = new Properties()
-    p.putAll(props.asJava)
+    props.foreach(v => p.put(v._1, v._2))
     _props.readPropertiesAs(p, _schema, classOf[InventoryLinkingConsolidationRequest])
   }
 }

--- a/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/InventoryLinkingConsolidationRequest.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/InventoryLinkingConsolidationRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
 
 package uk.gov.hmrc.wco.dec.inventorylinking.consolidation.request
 
-import java.io.StringWriter
-import java.util.Properties
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.dataformat.xml.annotation.{JacksonXmlProperty, JacksonXmlRootElement}
 import uk.gov.hmrc.wco.dec.inventorylinking.common.UcrBlock
 import uk.gov.hmrc.wco.dec.inventorylinking.movement.request.InventoryLinkingMovementRequest
 import uk.gov.hmrc.wco.dec.utilities.JacksonMapper
 
+import java.io.StringWriter
+import java.util.Properties
 import scala.collection.JavaConverters._
 
 object InventoryLinkingConsolidationRequest extends JacksonMapper {

--- a/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequest.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequest.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequest.scala
@@ -18,13 +18,12 @@ package uk.gov.hmrc.wco.dec.inventorylinking.movement.request
 
 import java.io.StringWriter
 import java.util.Properties
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.dataformat.xml.annotation.{JacksonXmlProperty, JacksonXmlRootElement}
 import uk.gov.hmrc.wco.dec.inventorylinking.common.{AgentDetails, TransportDetails, UcrBlock}
 import uk.gov.hmrc.wco.dec.utilities.JacksonMapper
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.propertiesAsScalaMapConverter
 
 
 object InventoryLinkingMovementRequest extends JacksonMapper {
@@ -35,7 +34,7 @@ object InventoryLinkingMovementRequest extends JacksonMapper {
 
   def fromProperties(props: Map[String, String]): InventoryLinkingMovementRequest = {
     val p = new Properties()
-    p.putAll(props.asJava)
+    props.foreach(v => p.put(v._1, v._2))
     _props.readPropertiesAs(p, _schema, classOf[InventoryLinkingMovementRequest])
   }
 }

--- a/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponse.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponse.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponse.scala
@@ -18,13 +18,13 @@ package uk.gov.hmrc.wco.dec.inventorylinking.movement.response
 
 import java.io.StringWriter
 import java.util.Properties
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.dataformat.xml.annotation.{JacksonXmlProperty, JacksonXmlRootElement}
 import uk.gov.hmrc.wco.dec.inventorylinking.common.{EntryStatus, GoodsItem, UcrBlock}
 import uk.gov.hmrc.wco.dec.utilities.JacksonMapper
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.propertiesAsScalaMapConverter
+
 
 @JsonIgnoreProperties(Array("_xml", "_schema", "_props"))
 @JacksonXmlRootElement(namespace = InventoryLinkingMovementResponse.namespace, localName = "inventoryLinkingMovementResponse")
@@ -78,7 +78,7 @@ object InventoryLinkingMovementResponse extends JacksonMapper {
 
   def fromProperties(props: Map[String, String]): InventoryLinkingMovementResponse = {
     val p = new Properties()
-    p.putAll(props.asJava)
+    props.foreach(v => p.put(v._1, v._2))
     _props.readPropertiesAs(p, _schema, classOf[InventoryLinkingMovementResponse])
   }
 }

--- a/src/main/scala/uk/gov/hmrc/wco/dec/status/StatusRequest.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/status/StatusRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/wco/dec/utilities/DateTimeFormats.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/utilities/DateTimeFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/wco/dec/utilities/JacksonMapper.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/utilities/JacksonMapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/wco/dec/utilities/SeqDeserializationModifier.scala
+++ b/src/main/scala/uk/gov/hmrc/wco/dec/utilities/SeqDeserializationModifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/DeclarationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/DeclarationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/DeclarationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/DeclarationSpec.scala
@@ -1711,7 +1711,7 @@ class DeclarationSpec extends WcoSpec with XmlBehaviours {
   "Date Time Formatter" should {
     "accept and recognize 102 date format" in {
       val date = DateTimeString(dateWithooutZoneFormat, year + month + day)
-      val parsedDate = date.time
+      val parsedDate = date.time()
 
       parsedDate.getYear must be(year.toInt)
       parsedDate.getMonthValue must be(month.toInt)
@@ -1723,7 +1723,7 @@ class DeclarationSpec extends WcoSpec with XmlBehaviours {
       val time = year + month + day + hour + minute + second + zone
 
       val date = DateTimeString(dateWithZoneFormat, time)
-      val parsedDate = date.time
+      val parsedDate = date.time()
 
       parsedDate.getYear must be(year.toInt)
       parsedDate.getMonthValue must be(month.toInt)
@@ -1738,7 +1738,7 @@ class DeclarationSpec extends WcoSpec with XmlBehaviours {
       val time = year + month + day + hour + minute + second + zone
 
       val date = DateTimeString(dateWithZoneFormat, time)
-      val parsedDate = date.time
+      val parsedDate = date.time()
 
       parsedDate.getYear must be(year.toInt)
       parsedDate.getMonthValue must be(month.toInt)
@@ -1753,7 +1753,7 @@ class DeclarationSpec extends WcoSpec with XmlBehaviours {
       val time = year + month + day + hour + minute + second + zone
 
       val date = DateTimeString(dateWithZoneFormat, time)
-      val parsedDate = date.time
+      val parsedDate = date.time()
 
       parsedDate.getYear must be(year.toInt)
       parsedDate.getMonthValue must be(month.toInt)

--- a/src/test/scala/uk/gov/hmrc/wco/dec/ResponseSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/ResponseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/TypeCodeValuesSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/TypeCodeValuesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/WcoSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/WcoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.wco.dec
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.wco.dec.inventorylinking.consolidation.request.InventoryLinkingConsolidationRequest
 import uk.gov.hmrc.wco.dec.inventorylinking.movement.request.InventoryLinkingMovementRequest
 import uk.gov.hmrc.wco.dec.inventorylinking.movement.response.InventoryLinkingMovementResponse
@@ -25,7 +26,7 @@ import uk.gov.hmrc.wco.dec.inventorylinking.movement.response.InventoryLinkingMo
 import scala.util.Random
 import scala.xml.{Elem, XML}
 
-trait WcoSpec extends WordSpec with MustMatchers with ScalaFutures {
+trait WcoSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   protected def randomCancelDeclaration: MetaData = MetaData(
     wcoDataModelVersionCode = Some(randomString(6)),

--- a/src/test/scala/uk/gov/hmrc/wco/dec/XmlBehaviours.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/XmlBehaviours.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,12 @@ import javax.xml.XMLConstants
 import javax.xml.transform.Source
 import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.{Schema, SchemaFactory}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.xml.{Elem, SAXException}
 
 trait XmlBehaviours {
-  this: WordSpec =>
+  this: AnyWordSpec =>
 
   val importDeclarationSchemaResources = Seq("/DocumentMetaData_2_DMS.xsd", "/WCO_DEC_2_DMS.xsd")
 

--- a/src/test/scala/uk/gov/hmrc/wco/dec/input/ResponseSpecInputXMLProvider.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/input/ResponseSpecInputXMLProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/ConsolidationRequestFromXmlSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/ConsolidationRequestFromXmlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/ConsolidationRequestSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/ConsolidationRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/ConsolidationRequestToXmlSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/ConsolidationRequestToXmlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/input/ConsolidationRequestSpecInputXMLProvider.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/consolidation/request/input/ConsolidationRequestSpecInputXMLProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequestFromXmlSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequestFromXmlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequestSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequestToXmlSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/InventoryLinkingMovementRequestToXmlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/input/MovementRequestSpecInputXMLProvider.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/request/input/MovementRequestSpecInputXMLProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponseFromXmlSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponseFromXmlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponseSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponseToXmlSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/InventoryLinkingMovementResponseToXmlSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/input/MovementResponseXMLProvider.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/inventorylinking/movement/response/input/MovementResponseXMLProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/status/StatusRequestSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/status/StatusRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/wco/dec/status/StatusRequestSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/status/StatusRequestSpec.scala
@@ -112,7 +112,7 @@ class StatusRequestSpec extends WcoSpec {
     "accept and recognize 102 date format" in {
       val time = year + month + day
       val date = DateTime(Some(dateWithooutZoneFormat), Some(time))
-      val parsedDate = date.timeOpt.get
+      val parsedDate = date.timeOpt().get
 
       parsedDate.getYear must be(year.toInt)
       parsedDate.getMonthValue must be(month.toInt)
@@ -124,7 +124,7 @@ class StatusRequestSpec extends WcoSpec {
       val time = year + month + day + hour + minute + second + zone
 
       val date = DateTime(Some(dateWithZoneFormat), Some(time))
-      val parsedDate = date.timeOpt.get
+      val parsedDate = date.timeOpt().get
 
       parsedDate.getYear must be(year.toInt)
       parsedDate.getMonthValue must be(month.toInt)
@@ -139,7 +139,7 @@ class StatusRequestSpec extends WcoSpec {
       val time = year + month + day + hour + minute + second + zone
 
       val date = DateTime(Some(dateWithZoneFormat), Some(time))
-      val parsedDate = date.timeOpt.get
+      val parsedDate = date.timeOpt().get
 
       parsedDate.getYear must be(year.toInt)
       parsedDate.getMonthValue must be(month.toInt)
@@ -154,7 +154,7 @@ class StatusRequestSpec extends WcoSpec {
       val time = year + month + day + hour + minute + second + zone
 
       val date = DateTime(Some(dateWithZoneFormat), Some(time))
-      val parsedDate = date.timeOpt.get
+      val parsedDate = date.timeOpt().get
 
       parsedDate.getYear must be(year.toInt)
       parsedDate.getMonthValue must be(month.toInt)

--- a/src/test/scala/uk/gov/hmrc/wco/dec/utilities/DateTimeFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/wco/dec/utilities/DateTimeFormatsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 
 package uk.gov.hmrc.wco.dec.utilities
-import org.scalatest.{MustMatchers, WordSpec}
+import uk.gov.hmrc.wco.dec.WcoSpec
 
-class DateTimeFormatsSpec extends WordSpec with MustMatchers {
+class DateTimeFormatsSpec extends WcoSpec {
   import DateTimeFormatsSpec._
 
   "DateTimeFormats" should {


### PR DESCRIPTION
`wco-dec` is a dependency for our BE service and this updates it to 2.13. It will still cross-compile to 2.11 and 2.12.